### PR TITLE
Fix only lowercase tag for GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.IMAGE_NAME}}:latest
+          tags: ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
Added env image_name variable for lowercase repository name to be used in the build tag.